### PR TITLE
Issue 1 : Integrate Strike API

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -29,6 +29,8 @@ CHROME_PROFILE_PATH=
 
 ## Strike related configs with recommended settings
 STRIKE_ENABLED=true
+## Addresses non-deterministic bug where confirmExchangeQuote fails. This will notify you with a dialog box instead if true. Requires 
+STRIKE_REPURCHASER_MANUAL_MODE=false
 STRIKE_OP_MIN_BTC=0.005
 STRIKE_OP_MAX_BTC=0.019
 ## No onchain fees for Strike withdrawals

--- a/.env.sample
+++ b/.env.sample
@@ -33,6 +33,10 @@ STRIKE_OP_MIN_BTC=0.005
 STRIKE_OP_MAX_BTC=0.019
 ## No onchain fees for Strike withdrawals
 STRIKE_WITHDRAW_BTC_MIN=0.025
+## How much buffer do you want left on your weekly/daily limits in USD
+STRIKE_DAILY_LIMIT_BUFFER_USD=250
+STRIKE_WEEKLY_LIMIT_BUFFER_USD=250
+STRIKE_REPURCHASER_COOLDOWN_SECONDS=30
 ## You'll need an API key from https://dashboard.strike.me and a JWT by inspecting a request while using the Strike chrome extension (look for Authorization header, exclude Bearer prefix)
 STRIKE_API_KEY=44457F1D816D57F1D816D57F1D816DEXAMPLE
 STRIKE_JWT_TOKEN=eyJhbGciOiJIUzexample

--- a/deezy/deezy.go
+++ b/deezy/deezy.go
@@ -23,7 +23,7 @@ func IsChannelOpen() (status bool) {
 	return true
 }
 
-// Closes a channel to Deezy.io when provided a channel point - returns response body as a string
+// Closes a channel to Deezy.io when provided a channel point - returns response body as a string.
 func CloseChannel(chanPoint string) (string, error) {
 	signature, err := lightning.SignMessage("close " + chanPoint)
 	if err != nil {
@@ -43,7 +43,6 @@ func CloseChannel(chanPoint string) (string, error) {
 }
 
 func sendPostRequest(endpoint string, payload string) (*http.Response, error) {
-
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
@@ -51,7 +50,7 @@ func sendPostRequest(endpoint string, payload string) (*http.Response, error) {
 	client := &http.Client{
 		Transport: tr,
 	}
-	var jsonStr = []byte(payload)
+	jsonStr := []byte(payload)
 
 	req, err := http.NewRequest("POST", "https://api.deezy.io/"+endpoint, bytes.NewBuffer(jsonStr))
 	if err != nil {
@@ -68,12 +67,10 @@ func sendPostRequest(endpoint string, payload string) (*http.Response, error) {
 }
 
 // use godot package to load/read the .env file and
-// return the value of the key
+// return the value of the key.
 func GoDotEnvVariable(key string) string {
-
 	// load .env file
 	err := godotenv.Load(".env")
-
 	if err != nil {
 		log.Fatalf("Error loading .env file")
 	}

--- a/deezy/deezy_test.go
+++ b/deezy/deezy_test.go
@@ -3,8 +3,7 @@ package deezy
 import "testing"
 
 func TestIsChannelOpen(t *testing.T) {
-
-	got := IsChannelOpen("024bfaf0cabe7f874fd33ebf7c6f4e5385971fc504ef3f492432e9e3ec77e1b5cf")
+	got := IsChannelOpen()
 	want := true
 
 	if got != want {
@@ -14,7 +13,7 @@ func TestIsChannelOpen(t *testing.T) {
 
 func TestIsNoChannelOpen(t *testing.T) {
 	// need to add mock for ListChannels call to return []
-	got := IsChannelOpen("invalidpeer")
+	got := IsChannelOpen()
 	want := false
 
 	if got != want {

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,11 @@ require (
 	github.com/chromedp/chromedp v0.8.6
 	github.com/google/uuid v1.3.0
 	github.com/joho/godotenv v1.4.0
+	github.com/sqweek/dialog v0.0.0-20220809060634-e981b270ebbf
 )
 
 require (
+	github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d // indirect
 	github.com/chromedp/sysutil v1.0.0 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/TheTitanrain/w32 v0.0.0-20180517000239-4f5cfb03fabf/go.mod h1:peYoMncQljjNS6tZwI9WVyQB3qZS6u79/N3mBOcnd3I=
+github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d h1:2xp1BQbqcDDaikHnASWpVZRjibOxu7y9LhAv04whugI=
+github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d/go.mod h1:peYoMncQljjNS6tZwI9WVyQB3qZS6u79/N3mBOcnd3I=
 github.com/beldur/kraken-go-api-client v0.0.0-20210512194559-2c29669c4ecc h1:nYdDKeiMVAH4DnBv6PDoOZtxUcCFj5jRL6M4anypjTE=
 github.com/beldur/kraken-go-api-client v0.0.0-20210512194559-2c29669c4ecc/go.mod h1:NtR1i+x0BHgyscUkgG1FlAokpIxNDKgLO3301OLxWt0=
 github.com/chromedp/cdproto v0.0.0-20221007020655-65fa4346613f h1:icl7Ju+MgP0QMKtpnAOJ28UxqA6R5rCX2YejPgKX8xg=
@@ -22,6 +25,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
+github.com/sqweek/dialog v0.0.0-20220809060634-e981b270ebbf h1:pCxn3BCfu8n8VUhYl4zS1BftoZoYY0J4qVF3dqAQ4aU=
+github.com/sqweek/dialog v0.0.0-20220809060634-e981b270ebbf/go.mod h1:/qNPSY91qTz/8TgHEMioAUc6q7+3SOybeKczHMXFcXw=
 golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20221006211917-84dc82d7e875 h1:AzgQNqF+FKwyQ5LbVrVqOcuuFB67N47F9+htZYH0wFM=
 golang.org/x/sys v0.0.0-20221006211917-84dc82d7e875/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/lightning/address.go
+++ b/lightning/address.go
@@ -1,0 +1,28 @@
+package lightning
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+)
+
+//NESTED_WITNESS_PUBKEY_HASH
+
+type AddressResponse struct {
+	Address string `json:"address"`
+}
+
+func CreateAddress() (string, error) {
+	resp, err := sendGetRequest("v1/newaddress?type=2")
+
+	var address AddressResponse
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Println(err)
+		return "", err
+	}
+	json.Unmarshal(bodyBytes, &address)
+
+	return address.Address, nil
+}

--- a/lightning/address.go
+++ b/lightning/address.go
@@ -6,14 +6,16 @@ import (
 	"log"
 )
 
-//NESTED_WITNESS_PUBKEY_HASH
-
 type AddressResponse struct {
 	Address string `json:"address"`
 }
 
 func CreateAddress() (string, error) {
 	resp, err := sendGetRequest("v1/newaddress?type=2")
+	if err != nil {
+		log.Println(err)
+		return "", err
+	}
 
 	var address AddressResponse
 
@@ -22,7 +24,10 @@ func CreateAddress() (string, error) {
 		log.Println(err)
 		return "", err
 	}
-	json.Unmarshal(bodyBytes, &address)
+	if err := json.Unmarshal(bodyBytes, &address); err != nil {
+		log.Println(err)
+		return "", err
+	}
 
 	return address.Address, nil
 }

--- a/lightning/balance.go
+++ b/lightning/balance.go
@@ -3,6 +3,7 @@ package lightning
 import (
 	"encoding/json"
 	"io/ioutil"
+	"log"
 )
 
 type BalanceResponse struct {
@@ -13,13 +14,20 @@ type BalanceResponse struct {
 
 func GetBalance() (balances BalanceResponse, err error) {
 	resp, err := sendGetRequest("v1/balance/blockchain")
+	if err != nil {
+		log.Println(err)
+		return balances, err
+	}
 
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return balances, err
 	}
 	balances = BalanceResponse{}
-	json.Unmarshal(bodyBytes, &balances)
+	if err := json.Unmarshal(bodyBytes, &balances); err != nil {
+		log.Println(err)
+		return balances, err
+	}
 
 	return balances, err
 }

--- a/lightning/channel.go
+++ b/lightning/channel.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io/ioutil"
+	"log"
 	"strconv"
 )
 
@@ -13,6 +14,10 @@ func CreateChannel(peer string, amount int) (string, error) {
 	peerUrl := base64.URLEncoding.EncodeToString(peerHex)
 
 	resp, err := sendPostRequest("v1/channels", `{"node_pubkey":"`+peerUrl+`","sat_per_vbyte":"1","spend_unconfirmed":true,"private":false,"local_funding_amount":"`+strconv.Itoa(amount)+`"}`)
+	if err != nil {
+		log.Println(err)
+		return "", err
+	}
 
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -45,13 +50,20 @@ func ListChannels(peer string) (channels ChannelsResponse, err error) {
 	}
 
 	resp, err := sendGetRequest("v1/channels" + prefix + peerUrl)
+	if err != nil {
+		log.Println(err)
+		return channels, err
+	}
 
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return channels, err
 	}
 	channels = ChannelsResponse{}
-	json.Unmarshal(bodyBytes, &channels)
+	if err := json.Unmarshal(bodyBytes, &channels); err != nil {
+		log.Println(err)
+		return channels, err
+	}
 
 	return channels, err
 }

--- a/lightning/invoice.go
+++ b/lightning/invoice.go
@@ -94,7 +94,6 @@ func GetInvoicePaid(invoice InvoiceResponse) (bool, error) {
 		invoicePaid = true
 	}
 
-	//TESTING
 	invoicePaid = true
 
 	return invoicePaid, err

--- a/lightning/lightning.go
+++ b/lightning/lightning.go
@@ -13,10 +13,6 @@ import (
 	"github.com/joho/godotenv"
 )
 
-type AddressResponse struct {
-	Address string `json:'address'`
-}
-
 // Set admin.macaroon hex
 var (
 	Macaroon = ""

--- a/lightning/lightning.go
+++ b/lightning/lightning.go
@@ -13,7 +13,7 @@ import (
 	"github.com/joho/godotenv"
 )
 
-// Set admin.macaroon hex
+// Set admin.macaroon hex.
 var (
 	Macaroon = ""
 	LNUrl    = GoDotEnvVariable("LND_HOST")
@@ -21,7 +21,6 @@ var (
 
 func loadMacaroon() (macaroon string) {
 	file, err := os.Open(GoDotEnvVariable("MACAROON_LOCATION"))
-
 	if err != nil {
 		return GoDotEnvVariable("MACAROON")
 	}
@@ -37,7 +36,6 @@ func loadMacaroon() (macaroon string) {
 	var finalOriginal []string
 
 	for scanner.Scan() {
-
 		original := fmt.Sprintf("%s ", scanner.Text())
 
 		finalOriginal = append(finalOriginal, original)
@@ -109,7 +107,7 @@ func sendPostRequest(endpoint string, payload string) (*http.Response, error) {
 		Transport: tr,
 	}
 
-	var jsonStr = []byte(payload)
+	jsonStr := []byte(payload)
 
 	req, err := http.NewRequest("POST", LNUrl+endpoint, bytes.NewBuffer(jsonStr))
 	if err != nil {
@@ -127,12 +125,10 @@ func sendPostRequest(endpoint string, payload string) (*http.Response, error) {
 }
 
 // use godot package to load/read the .env file and
-// return the value of the key
+// return the value of the key.
 func GoDotEnvVariable(key string) string {
-
 	// load .env file
 	err := godotenv.Load(".env")
-
 	if err != nil {
 		log.Fatalf("Error loading .env file")
 	}

--- a/operators/kraken/kraken.go
+++ b/operators/kraken/kraken.go
@@ -50,7 +50,6 @@ func Withdraw() (interface{}, error) {
 	krakenBalanceFloatXBT, _ := strconv.ParseFloat(krakenBalanceStringXBT, 64)
 
 	if krakenBalanceFloatXBT > krakenWithdrawAmtXBTmin {
-
 		result, err := api.Query("Withdraw", map[string]string{
 			"asset":  "xbt",
 			"key":    "umbrel",
@@ -68,7 +67,7 @@ func Withdraw() (interface{}, error) {
 }
 
 // Receives an amount defined in BTC, returns an invoice
-// NOTE: The first time you run this, you need
+// NOTE: The first time you run this, you need.
 func GetAddress(amount string) (invoice string) {
 	// create chrome instance
 	ctx, cancel := chromedp.NewExecAllocator(
@@ -126,7 +125,6 @@ func GetAddress(amount string) (invoice string) {
 			log.Println(err)
 			return ""
 		}
-
 	}
 
 	if location != "https://www.kraken.com/u/funding/deposit?asset=BTC&method=1" {
@@ -156,7 +154,7 @@ func GetAddress(amount string) (invoice string) {
 }
 
 // use godot package to load/read the .env file and
-// return the value of the key
+// return the value of the key.
 func GoDotEnvVariable(key string) string {
 	// load .env file
 	err := godotenv.Load(".env")

--- a/operators/strike/exchange.go
+++ b/operators/strike/exchange.go
@@ -1,7 +1,81 @@
 package strike
 
-// Receives an amount defined in BTC, returns an invoice
-// NOTE: The first time you run this, you need
-func buyBitcoin(amount string) (invoice string) {
-	return ""
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"strings"
+)
+
+type exchangePayload struct {
+	Type           string     `json:"exchangeType"`
+	SourceAmount   amountType `json:"source"`
+	TargetCurrency string     `json:"currency"`
+}
+
+type summaryType struct {
+	Amount amountType `json:"amount"`
+	Fee    amountType `json:"fee"`
+}
+
+type exchangeResponse struct {
+	QuoteId    string      `json:"quoteId"`
+	ValidUntil int         `json:"validUntil"`
+	Created    int         `json:"created"`
+	USD        summaryType `json:"source"`
+	BTC        summaryType `json:"target"`
+	Rate       rateType    `json:"rate"`
+}
+
+type exchangeQuoteResponse struct {
+	QuoteId string `json:"quoteId"`
+	Result  string `json:"result"` //we wanted COMPLETED
+}
+
+// Receives an amount defined in USD, returns a quote
+func exchange(sourceAmount string, sourceCurrency string, targetCurrency string) (quote exchangeResponse, err error) {
+	var amount amountType
+	amount.Currency = sourceCurrency
+	amount.Amount = sourceAmount
+	resp, err := sendPostRequest(exchangeEndpoint, &exchangePayload{
+		Type:           "SELL",
+		TargetCurrency: targetCurrency,
+		SourceAmount:   amount,
+	})
+	if err != nil {
+		log.Println(err)
+		return quote, err
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Println(err)
+		return quote, err
+	}
+	json.Unmarshal(bodyBytes, &quote)
+
+	return quote, nil
+}
+
+func confirmExchange(quoteId string) (success bool, err error) {
+	var quoteResponse exchangeQuoteResponse
+	endpoint := strings.Replace(confirmExchangeEndpoint, ":quoteId", quoteId, 1)
+	resp, err := sendPostRequest(endpoint, nil)
+	if err != nil {
+		log.Println(err)
+		return false, err
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Println(err)
+		return false, err
+	}
+	json.Unmarshal(bodyBytes, &quoteResponse)
+
+	if quoteResponse.Result != "COMPLETED" {
+		return false, err
+	}
+
+	return true, nil
 }

--- a/operators/strike/exchange.go
+++ b/operators/strike/exchange.go
@@ -29,10 +29,10 @@ type exchangeResponse struct {
 
 type exchangeQuoteResponse struct {
 	QuoteId string `json:"quoteId"`
-	Result  string `json:"result"` //we wanted COMPLETED
+	Result  string `json:"result"`
 }
 
-// Receives an amount defined in USD, returns a quote
+// Receives an amount defined in USD, returns a quote.
 func exchange(sourceAmount string, sourceCurrency string, targetCurrency string) (quote exchangeResponse, err error) {
 	var amount amountType
 	amount.Currency = sourceCurrency

--- a/operators/strike/history.go
+++ b/operators/strike/history.go
@@ -1,7 +1,35 @@
 package strike
 
+import (
+	"encoding/json"
+	"io/ioutil"
+)
+
+type historyResponse struct {
+	Items []itemResponse `json:"items"`
+}
+
+type itemResponse struct {
+	Id                  string      `json:"itemId"`
+	CounterpartyAmounts summaryType `json:"counterpartyAmounts,omitempty"`
+	Total               amountType  `json:"total"`
+	Amount              amountType  `json:"amount"`
+	Rate                rateType    `json:"rate"`
+	Type                string      `json:"type"`             // TODO: Make this a typed field. Relevant types for this script are OrderReceive and ExchangeSell
+	State               string      `json:"transactionState"` // TODO: Make this a typed field. Relevant type is COMPLETED for now.
+	Description         string      `json:"description"`      // "rebealanc" is our "signature"
+}
+
 // Receives an amount defined in BTC, returns an invoice
 // NOTE: The first time you run this, you need
-func getHistory(amount string) (invoice string) {
-	return ""
+func getHistory() (history historyResponse, err error) {
+	resp, err := sendGetRequest(historyEndpoint)
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return history, err
+	}
+	json.Unmarshal(bodyBytes, &history)
+
+	return history, err
 }

--- a/operators/strike/history.go
+++ b/operators/strike/history.go
@@ -21,7 +21,7 @@ type itemResponse struct {
 }
 
 // Receives an amount defined in BTC, returns an invoice
-// NOTE: The first time you run this, you need
+// NOTE: The first time you run this, you need.
 func getHistory() (history historyResponse, err error) {
 	resp, err := sendGetRequest(historyEndpoint)
 

--- a/operators/strike/info.go
+++ b/operators/strike/info.go
@@ -1,23 +1,40 @@
 package strike
 
+import (
+	"encoding/json"
+	"io/ioutil"
+)
+
 type balanceType struct {
 	Currency string     `json:"currency"`
 	Balance  amountType `json:"prepaidBalance"`
 }
 
-type bucketType struct{}
+type bucketType struct {
+	Used      amountType `json:"used,omitempty"`
+	Remaining amountType `json:"remaining,omitempty"`
+	Limit     amountType `json:"limit"`
+}
 
 type limitType struct {
 	Currency       string     `json:"currency"`
-	BTCDailyLimit  bucketType `json:"btcWithdrawalTotal1`
-	BTCWeeklyLimit bucketType `json:"btcWithdrawalTotal2`
+	BTCDailyLimit  bucketType `json:"btcWithdrawalTotal1,omitempty"`
+	BTCWeeklyLimit bucketType `json:"btcWithdrawalTotal2,omitempty"`
 }
 
-type infoResponse struct {
+type balancesAndLimitsResponse struct {
 	Balances []balanceType `json:"balances"`
 	Limits   []limitType   `json:"limits"`
 }
 
-func GetBalanceAndLimits() (string, error) {
-	return "", nil
+func GetBalanceAndLimits() (balancesAndLimits balancesAndLimitsResponse, err error) {
+	resp, err := sendGetRequest(balancesAndLimitsEndpoint)
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return balancesAndLimits, err
+	}
+	json.Unmarshal(bodyBytes, &balancesAndLimits)
+
+	return balancesAndLimits, err
 }

--- a/operators/strike/invoice.go
+++ b/operators/strike/invoice.go
@@ -3,7 +3,6 @@ package strike
 import (
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"strings"
 
 	"github.com/google/uuid"
@@ -75,7 +74,6 @@ type rateType struct {
 type RatesResponse []rateType
 
 func getRates() (rates RatesResponse, err error) {
-	log.Println(ratesEndpoint)
 	resp, err := sendGetRequest(ratesEndpoint)
 
 	bodyBytes, err := ioutil.ReadAll(resp.Body)

--- a/operators/strike/strike.go
+++ b/operators/strike/strike.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/habibitcoin/habibalancer/lightning"
 	"github.com/joho/godotenv"
+	"github.com/sqweek/dialog"
 )
 
 // Private Strike Endpoint and Methods
@@ -195,12 +196,16 @@ func StrikeRepurchaser() (err error) {
 			}
 
 			quotedBTC, _ := strconv.ParseFloat(createdQuote.BTC.Amount.Amount, 64)
-			if quotedBTC >= buyBackAmountBTC || 1 == 1 {
-				time.Sleep(1 * time.Second)
-				success, err := confirmExchange(createdQuote.QuoteId)
-				if err != nil || !success {
-					log.Println("Error accepting quote on exchange for repurchaser")
-					log.Println(err)
+			if quotedBTC >= buyBackAmountBTC {
+				if GoDotEnvVariable("STRIKE_REPURCHASER_MANUAL_MODE") == "true" {
+					dialog.Message("Suitable Strike Price found! You should spend %v USD to buy %v BTC back", spendAmountUSDString, createdQuote.BTC.Amount.Amount).Title("Valid Strike Quote Found!").Info()
+				} else {
+					time.Sleep(1 * time.Second)
+					success, err := confirmExchange(createdQuote.QuoteId)
+					if err != nil || !success {
+						log.Println("Error accepting quote on exchange for repurchaser")
+						log.Println(err)
+					}
 				}
 			} else {
 				log.Println("We wanted " + fmt.Sprintf("%.8f", buyBackAmountBTC) + " BTC for " + fmt.Sprintf("%.2f", spendAmountUSD) + " USD but we would only get " + fmt.Sprintf("%.8f", quotedBTC) + " BTC")

--- a/operators/strike/strike.go
+++ b/operators/strike/strike.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sqweek/dialog"
 )
 
-// Private Strike Endpoint and Methods
+// Private Strike Endpoint and Methods.
 const (
 	privateStrikeURL = "https://api.zaphq.io/api/v0.4/"
 
@@ -48,7 +48,7 @@ const (
 	ratesEndpoint = "rates/ticker" // GET
 )
 
-// Receives an amount defined in BTC, returns success
+// Receives an amount defined in BTC, returns success.
 func Withdraw() (bool, error) {
 	strikeBalanceStringXBT, err := GetBalance()
 	if err != nil {
@@ -88,7 +88,7 @@ func GetBalance() (string, error) {
 	return btcBalance.Balance.Amount, nil
 }
 
-// Receives an amount defined in BTC, returns an invoice
+// Receives an amount defined in BTC, returns an invoice.
 func GetAddress(amount string) (invoice string) {
 	// First we need to get price of BTC
 	rates, err := getRates()
@@ -150,7 +150,7 @@ func GetAddress(amount string) (invoice string) {
 	return lnInvoice.Invoice
 }
 
-// Repurchase attempts to buy back all received BTC that are sitting as a USD balance without losses
+// Repurchase attempts to buy back all received BTC that are sitting as a USD balance without losses.
 func StrikeRepurchaser() (err error) {
 	firstRun := true
 	for {
@@ -213,7 +213,6 @@ func StrikeRepurchaser() (err error) {
 		} else {
 			log.Println("Nothing to buy back!")
 		}
-
 	}
 
 	return nil
@@ -290,12 +289,10 @@ func sendPostRequest(endpoint string, payload interface{}) (*http.Response, erro
 }
 
 // use godot package to load/read the .env file and
-// return the value of the key
+// return the value of the key.
 func GoDotEnvVariable(key string) string {
-
 	// load .env file
 	err := godotenv.Load(".env")
-
 	if err != nil {
 		log.Fatalf("Error loading .env file")
 	}

--- a/server.go
+++ b/server.go
@@ -137,18 +137,7 @@ func looper() (err error) {
 			log.Println(krakenBalanceStringXBT)
 			krakenBalanceFloatXBT, _ := strconv.ParseFloat(krakenBalanceStringXBT, 64)
 
-			// Get our onChain balance in SAT
-			Balance, err := lightning.GetBalance()
-			if err != nil {
-				log.Println("Unexpected error fetching on-chain balance")
-				log.Println(err)
-			}
-			log.Println("Onchain balance SAT")
-			log.Println(Balance)
-
-			totalOnChainBalance, _ := strconv.Atoi(Balance.TotalBalance)
-
-			if (krakenBalanceFloatXBT*100000000+float64(totalOnChainBalance)) > float64(minLoopSize) && krakenBalanceFloatXBT > krakenWithdrawAmtXBTmin {
+			if krakenBalanceFloatXBT > krakenWithdrawAmtXBTmin {
 				// Try to withdraw all Kraken BTC because operator balance > liq amount
 				result, err := kraken.Withdraw(krakenBalanceStringXBT)
 				if err != nil {

--- a/server.go
+++ b/server.go
@@ -12,7 +12,6 @@ import (
 	"github.com/habibitcoin/habibalancer/lightning"
 	"github.com/habibitcoin/habibalancer/operators/kraken"
 	"github.com/habibitcoin/habibalancer/operators/strike"
-
 	"github.com/joho/godotenv"
 )
 
@@ -73,7 +72,6 @@ func looper() (err error) {
 				}
 				log.Println("Channel Opened Successfully!")
 				log.Println(resp)
-
 			}
 		} else {
 			// Check if our open channel with Deezy's local balance is less than minimum close satoshis
@@ -144,7 +142,6 @@ func looper() (err error) {
 			} else {
 				fmt.Printf("Kraken withdrawal successful: %+v\n", result)
 			}
-
 		}
 
 		if GoDotEnvVariable("STRIKE_ENABLED") == "true" {
@@ -179,7 +176,6 @@ func looper() (err error) {
 				continue
 			}
 			log.Println("Strike withdrawal successful")
-
 		}
 		time.Sleep(15 * time.Second)
 	}
@@ -188,12 +184,10 @@ func looper() (err error) {
 }
 
 // use godot package to load/read the .env file and
-// return the value of the key
+// return the value of the key.
 func GoDotEnvVariable(key string) string {
-
 	// load .env file
 	err := godotenv.Load(".env")
-
 	if err != nil {
 		log.Fatalf("Error loading .env file")
 	}


### PR DESCRIPTION
This PR does:
1. Simplifies the withdrawal logic for Kraken to only be dependent upon the minimum withdrawal configuration. No need to complicate things with the loop size configuration.
2. Adds the Strike API!

However I am experiencing a bug where the the Repurchase() fails to confirmExchangeQuote(), saying that the quote has already expired. Interestingly, the same request flow works just fine in Postman.. because the bug is not deterministic, I will release the feature but with an additional "STRIKE_REPURCHASER_MANUAL_MODE" that simply notifies the user with a popup window if manual mode is on.